### PR TITLE
Add types and refactor into src

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [push, workflow_dispatch]
+on: [push]
 
 jobs:
   test-node:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [push]
+on: [push, workflow_dispatch]
 
 jobs:
   test-node:

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -22,6 +22,21 @@ dev = [
     "toml ~=0.10.2",
     "yapf ~=0.32.0",
 ]
+test = [
+    "pytest~=7.4.2",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+groundcontrolsh = ["py.typed"]
+
+[tool.pytest.ini_options]
+pythonpath = "src"
+addopts = [
+    "--import-mode=importlib",
+]
 
 [build-system]
 build-backend = "setuptools.build_meta"

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -22,21 +22,12 @@ dev = [
     "toml ~=0.10.2",
     "yapf ~=0.32.0",
 ]
-test = [
-    "pytest~=7.4.2",
-]
 
 [tool.setuptools.packages.find]
 where = ["src"]
 
 [tool.setuptools.package-data]
 groundcontrolsh = ["py.typed"]
-
-[tool.pytest.ini_options]
-pythonpath = "src"
-addopts = [
-    "--import-mode=importlib",
-]
 
 [build-system]
 build-backend = "setuptools.build_meta"

--- a/packages/python/src/groundcontrolsh/__init__.py
+++ b/packages/python/src/groundcontrolsh/__init__.py
@@ -1,0 +1,1 @@
+from .groundcontrolsh import GroundControl as GroundControl

--- a/packages/python/src/groundcontrolsh/groundcontrolsh.py
+++ b/packages/python/src/groundcontrolsh/groundcontrolsh.py
@@ -1,21 +1,22 @@
 import requests
 import time
 from urllib.parse import quote
+import typing as t
 
 class GroundControl:
 
-    def __init__(self, project_id, api_key, **options):
-        self.project_id = project_id
-        self.api_key = api_key
-        self.base_url = options.get('base_url', 'https://api.groundcontrol.sh')
-        self.ttl = options.get('cache')
-        self.cache = {}
+    def __init__(self, project_id: str, api_key: str, **options: t.Any) -> None:
+        self.project_id: str = project_id
+        self.api_key: str = api_key
+        self.base_url: str = options.get('base_url', 'https://api.groundcontrol.sh')
+        self.ttl: int | None = options.get('cache')
+        self.cache: t.Dict[str, t.Dict[str, t.Any]] = {}
 
-        self.actor_overrides = {}
-        self.flag_overrides = {}
-        self.full_override = None
+        self.actor_overrides: t.Dict[str, t.Dict[str, bool]] = {}
+        self.flag_overrides: t.Dict[str, bool] = {}
+        self.full_override: bool | None = None
 
-    def is_feature_flag_enabled(self, flag_name, options=None):
+    def is_feature_flag_enabled(self, flag_name: str, options: t.Dict[str, t.Any] | None = None) -> bool:
         options = options or {}
         actors = options.get('actors', [])
 
@@ -60,24 +61,24 @@ class GroundControl:
 
         return enabled
 
-    def disable_feature_flag(self, flag_name, options=None):
+    def disable_feature_flag(self, flag_name: str, options: t.Dict[str, t.Any] | None = None) -> None:
         self.set_feature_flag_enabled(False, flag_name, options)
 
-    def disable_all_feature_flags(self):
+    def disable_all_feature_flags(self) -> None:
         self.full_override = False
 
-    def enable_feature_flag(self, flag_name, options=None):
+    def enable_feature_flag(self, flag_name: str, options: t.Dict[str, t.Any] | None = None) -> None:
         self.set_feature_flag_enabled(True, flag_name, options)
 
-    def enable_all_feature_flags(self):
+    def enable_all_feature_flags(self) -> None:
         self.full_override = True
 
-    def reset(self):
+    def reset(self) -> None:
         self.actor_overrides.clear()
         self.flag_overrides.clear()
         self.full_override = None
 
-    def set_feature_flag_enabled(self, enabled, flag_name, options=None):
+    def set_feature_flag_enabled(self, enabled, flag_name: str, options: t.Dict[str, t.Any] | None = None) -> None:
         options = options or {}
         actors_ops = options.get('actors')
 

--- a/packages/python/src/groundcontrolsh/groundcontrolsh.py
+++ b/packages/python/src/groundcontrolsh/groundcontrolsh.py
@@ -9,14 +9,14 @@ class GroundControl:
         self.project_id: str = project_id
         self.api_key: str = api_key
         self.base_url: str = options.get('base_url', 'https://api.groundcontrol.sh')
-        self.ttl: int | None = options.get('cache')
+        self.ttl: t.Optional[int] = options.get('cache')
         self.cache: t.Dict[str, t.Dict[str, t.Any]] = {}
 
         self.actor_overrides: t.Dict[str, t.Dict[str, bool]] = {}
         self.flag_overrides: t.Dict[str, bool] = {}
-        self.full_override: bool | None = None
+        self.full_override: t.Optional[bool] = None
 
-    def is_feature_flag_enabled(self, flag_name: str, options: t.Dict[str, t.Any] | None = None) -> bool:
+    def is_feature_flag_enabled(self, flag_name: str, options: t.Optional[t.Dict[str, t.Any]] = None) -> bool:
         options = options or {}
         actors = options.get('actors', [])
 
@@ -61,13 +61,13 @@ class GroundControl:
 
         return enabled
 
-    def disable_feature_flag(self, flag_name: str, options: t.Dict[str, t.Any] | None = None) -> None:
+    def disable_feature_flag(self, flag_name: str, options: t.Optional[t.Dict[str, t.Any]] = None) -> None:
         self.set_feature_flag_enabled(False, flag_name, options)
 
     def disable_all_feature_flags(self) -> None:
         self.full_override = False
 
-    def enable_feature_flag(self, flag_name: str, options: t.Dict[str, t.Any] | None = None) -> None:
+    def enable_feature_flag(self, flag_name: str, options: t.Optional[t.Dict[str, t.Any]] = None) -> None:
         self.set_feature_flag_enabled(True, flag_name, options)
 
     def enable_all_feature_flags(self) -> None:
@@ -78,7 +78,7 @@ class GroundControl:
         self.flag_overrides.clear()
         self.full_override = None
 
-    def set_feature_flag_enabled(self, enabled, flag_name: str, options: t.Dict[str, t.Any] | None = None) -> None:
+    def set_feature_flag_enabled(self, enabled, flag_name: str, options: t.Optional[t.Dict[str, t.Any]] = None) -> None:
         options = options or {}
         actors_ops = options.get('actors')
 

--- a/packages/python/tests/test_groundcontrolsh.py
+++ b/packages/python/tests/test_groundcontrolsh.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch
 import time
-from src.groundcontrolsh import GroundControl
+from groundcontrolsh import GroundControl
 
 
 class TestGroundControl(unittest.TestCase):


### PR DESCRIPTION
Adds types to the Python SDK and applies a _src layout_ which [adds some advantages](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/) (this is a matter of taste, to be fair)

It also modifies `pyproject.toml` file and the tests to reflect the named changes.